### PR TITLE
Accept empty map of offsets instead of throwing

### DIFF
--- a/src/main/kotlin/com/omarsmak/kafka/consumer/lag/monitoring/client/impl/KafkaConsumerLagJavaClient.kt
+++ b/src/main/kotlin/com/omarsmak/kafka/consumer/lag/monitoring/client/impl/KafkaConsumerLagJavaClient.kt
@@ -31,7 +31,7 @@ internal class KafkaConsumerLagJavaClient (
         val offsets = javaAdminClient.listConsumerGroupOffsets(consumerGroup)
                 .partitionsToOffsetAndMetadata()
                 .get()
-        if (offsets == null || offsets.isEmpty())
+        if (offsets == null)
             throw KafkaConsumerLagClientException("Consumer group `$consumerGroup` does not exist in the Kafka cluster.")
 
         return getConsumerOffsetsPerTopic(offsets)


### PR DESCRIPTION
This change treats an empty map of offsets returned by the Kafka admin client for a consumer group as ok.

Why? Because a consumer group might exist without having "caused" any offset data, yet.