### PR TITLE
Allow more configuration for included/excluded consumer groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,15 @@ so prometheus server can scrap these metrics and expose them for example to graf
 ```
 kafka.bootstrap.servers=localhost:9092
 kafka.retry.backoff.ms = 200
-monitoring.lag.consumer.groups=test*
+monitoring.lag.consumer.groups=group-a-*,*-b-*,*-c
+monitoring.lag.consumer.groups.exclude=*test*
 monitoring.lag.prometheus.http.port=9772
 monitoring.lag.logging.rootLogger.appenderRef.stdout.ref=LogToConsole
 monitoring.lag.logging.rootLogger.level=info
 ```
-And then you can run it like the following:
+This will include consumer groups that either start with `group-a-`, contain `-b-`, or end with `-c`, excluding those containing `test`.
+
+You can then run it like the following:
 ##### Example Usage Native Application:
 ```
 ./kafka-consumer-lag-monitoring-prometheus-0.1.0 config.proprties

--- a/monitoring-core/src/main/kotlin/com/omarsmak/kafka/consumer/lag/monitoring/engine/MonitoringEngine.kt
+++ b/monitoring-core/src/main/kotlin/com/omarsmak/kafka/consumer/lag/monitoring/engine/MonitoringEngine.kt
@@ -27,6 +27,7 @@ class MonitoringEngine private constructor(monitoringComponent: MonitoringCompon
         const val DEFAULT_POLL_INTERVAL = 2000
 
         const val CONSUMER_GROUPS = "consumer.groups"
+        const val EXCLUDED_CONSUMER_GROUPS = "consumer.groups.exclude"
 
         fun createWithComponentAndConfigs(monitoringComponent: MonitoringComponent, configs: Map<String, Any?>): MonitoringEngine =
                 MonitoringEngine(monitoringComponent, configs)
@@ -79,7 +80,7 @@ class MonitoringEngine private constructor(monitoringComponent: MonitoringCompon
         timer.scheduleAtFixedRate(0, monitoringPollInterval) {
             try {
                 // get our full target consumer groups, however we do have to check here to make sure we catch any new consumer group
-                val consumerGroups = Utils.getTargetConsumerGroups(kafkaConsumerLagClient, initializeConsumerGroups())
+                val consumerGroups = Utils.getTargetConsumerGroups(kafkaConsumerLagClient, initializeConsumerGroups(), initializeExcludedConsumerGroups())
                 val diffConsumerGroups = Utils.updateAndTrackConsumerGroups(trackedConsumerGroups, consumerGroups, false)
                 trackedConsumerGroups = diffConsumerGroups.updatedConsumerGroups
 
@@ -173,6 +174,16 @@ class MonitoringEngine private constructor(monitoringComponent: MonitoringCompon
         }
 
         return consumerGroups.split(",")
+    }
+
+    private fun initializeExcludedConsumerGroups(): List<String> {
+        val excludedConsumerGroups = componentConfigs[EXCLUDED_CONSUMER_GROUPS] as String?
+
+        if (excludedConsumerGroups.isNullOrEmpty()) {
+            return listOf<String>();
+        }
+
+        return excludedConsumerGroups.split(",")
     }
 
 


### PR DESCRIPTION
Hi,

Here is another pull request that allows for more configurability in the monitored consumer groups:
- first, allow more precise wildcard matching (_starts with_, _contains_ or _ends with_ instead of just _starts with_)
- second, allow excluding groups

This allows, for example, to monitor _my-app-*_ and exclude _my-app-cache-*_.

Hope this helps!
Colin